### PR TITLE
Fix key names getting truncated sometimes

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -21,6 +21,8 @@ module.exports = function() {
     var parent = current;
     element = name;
     switch (name) {
+      case "key":
+        key = "";
       case "plist":
         current.version = attrs.version;
         break;
@@ -49,7 +51,7 @@ module.exports = function() {
 
   parser.on("text", function(text) {
     if (element === "key") {
-      key = text;
+      key += text;
     }
     var val = parse(text);
     if (typeof val === "string") {


### PR DESCRIPTION
Due to the streaming nature of the parser, it is not guaranteed that
an entire "text" value will be returned in one call. Thus, when parsing
larger XML libraries, previous code would get two consecutive calls, such
as "Artis" and "t", thus emitting a key of name "t".